### PR TITLE
fix #207 : Center the position of copyright part

### DIFF
--- a/style.css
+++ b/style.css
@@ -613,8 +613,21 @@ section {
 .copyright-text p {
   margin: 0;
   font-size: 16px;
-  color: #a0a0a0;
+  color: gray;
+  display: inline;
+  align-items: center;
 }
+
+@media screen and (min-width: 922px) {
+  .copyright-text p {
+  margin: 0 0 0 65px;
+  font-size: 16px;
+  color: gray;
+  display: inline;
+  align-items: center;
+}
+  }
+
 
 .copyright-text p a {
   color: #ff5e14;


### PR DESCRIPTION
### What does this PR do?
This PR fixes #207  by adding a css to center the copyright part in the footer.

**Screenshot**
![Screenshot 2023-10-01 133830](https://github.com/harshvardhansb/TourGuide/assets/123640518/e2a303de-90b9-4f6c-8359-17d9746aceb4)

