### PR TITLE
Fixes: the copyright section by align them in the centre

### DIFF
--- a/style.css
+++ b/style.css
@@ -8,7 +8,8 @@
 }
 
 .icon {
-  text-align: center;
+  display: flex;
+  justify-content: center;
 }
 
 .social-icon {
@@ -611,6 +612,7 @@ section {
 }
 
 .copyright-text p {
+  text-align: center;
   margin: 0;
   font-size: 16px;
   color: #a0a0a0;


### PR DESCRIPTION
fixes: #207 
i have made changes  in style.css to align centre  the copyright text in footer and also align the icons.